### PR TITLE
Return server status text instead of static error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const PSC = function (url, data = {}, options = {}) {
         })
     }).then(res => {
         if (res.ok) return res.json();
-        throw new Error('Response is not ok');
+        throw new Error(res.statusText);
     });
     
     if (socket) {


### PR DESCRIPTION
Getting server status message can alleviate debugging whenever error happens.